### PR TITLE
Use ts-command-line for deploy-to-heroku tool

### DIFF
--- a/deploy-to-heroku.ts
+++ b/deploy-to-heroku.ts
@@ -1,60 +1,115 @@
 import child_process from 'child_process';
+import { CommandLineParser, CommandLineStringParameter, CommandLineAction, CommandLineFlagParameter } from '@microsoft/ts-command-line';
 
-class Deployer {
+class DeployToHeroku extends CommandLineAction {
+  private _appName?: CommandLineStringParameter;
+  private _ignoreCache?: CommandLineFlagParameter;
+
+  constructor() {
+    super({
+      actionName: 'deploy',
+      summary: 'Deploy the app to Heroku.',
+      documentation: 'This command builds the app container and deploys it to Heroku.'
+    });
+  }
+
+  protected onDefineParameters() {
+    this._appName = this.defineStringParameter({
+      parameterShortName: '-a',
+      parameterLongName: '--app',
+      argumentName: 'APP_NAME',
+      description: 'The Heroku app name to deploy to.',
+      required: true
+    });
+
+    this._ignoreCache = this.defineFlagParameter({
+      parameterLongName: '--ignore-cache',
+      description: 'Do not pull existing container image or use it as a cache.'
+    });
+  }
+
+  protected async onExecute() {
+    const appName = (this._appName && this._appName.value) || '';
+    const ignoreCache = this._ignoreCache && this._ignoreCache.value;
+
+    const heroku = new HerokuDeployer(appName);
+
+    heroku.loginToRegistry();
+    if (ignoreCache) {
+      heroku.docker.build().push();
+    } else {
+      heroku.docker
+        .pull()
+        .build(`${heroku.containerTag}:latest`)
+        .push();
+    }
+    heroku.releaseContainer();
+  }
+}
+
+class DeployerCommandLine extends CommandLineParser {
+  constructor() {
+    super({
+      toolFilename: 'deployer',
+      toolDescription: 'Build and/or deploy nyc-doffer.'
+    });
+
+    this.addAction(new DeployToHeroku());
+  }
+
+  protected onDefineParameters() {
+  }
+}
+
+class DockerBuilder {
+  constructor(readonly containerTag: string) {
+  }
+
+  pull() {
+    runSync(`docker pull ${this.containerTag}`);
+    return this;
+  }
+
+  push() {
+    runSync(`docker push ${this.containerTag}`);
+    return this;
+  }
+
+  build(cacheFrom?: string) {
+    const cacheFromArg = cacheFrom ? `--cache-from ${cacheFrom}` : ``;
+    runSync(`docker build ${cacheFromArg} -t ${this.containerTag} .`);
+    return this;
+  }
+}
+
+class HerokuDeployer {
   readonly processType: string = 'web';
+  readonly docker: DockerBuilder;
 
   constructor(readonly herokuAppName: string) {
+    this.docker = new DockerBuilder(this.containerTag);
   }
 
   get containerTag() {
     return `registry.heroku.com/${this.herokuAppName}/${this.processType}`;
   }
 
-  private runSync(cmdline: string) {
-    console.log(`$ ${cmdline}`)
-    child_process.execSync(cmdline, {stdio: 'inherit'});
-  }
-
   loginToRegistry() {
-    this.runSync(`heroku container:login`);
-    return this;
-  }
-
-  pullFromRegistry() {
-    this.runSync(`docker pull ${this.containerTag}`);
-    return this;
-  }
-
-  pushToRegistry() {
-    this.runSync(`docker push ${this.containerTag}`);
-    return this;
-  }
-
-  buildContainer() {
-    this.runSync(`docker build --cache-from ${this.containerTag}:latest -t ${this.containerTag} .`);
+    runSync(`heroku container:login`);
     return this;
   }
 
   releaseContainer() {
-    this.runSync(`heroku container:release -a ${this.herokuAppName} ${this.processType}`);
+    runSync(`heroku container:release -a ${this.herokuAppName} ${this.processType}`);
     return this;
   }
 }
 
+function runSync(cmdline: string) {
+  console.log(`$ ${cmdline}`)
+  child_process.execSync(cmdline, {stdio: 'inherit'});
+}
+
 if (!module.parent) {
-  const herokuAppName = process.argv[2];
-
-  if (!herokuAppName) {
-    console.log(`usage: deploy-to-heroku <heroku app name>`);
-    process.exit(1);
-  }
-
-  const deployer = new Deployer(herokuAppName);
-
-  deployer
-    .loginToRegistry()
-    .pullFromRegistry()
-    .buildContainer()
-    .pushToRegistry()
-    .releaseContainer();
+  (new DeployerCommandLine()).execute();
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mocha": "^6.2.0"
   },
   "dependencies": {
+    "@microsoft/ts-command-line": "^4.3.2",
     "@types/cheerio": "^0.22.13",
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,15 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
   integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
 
+"@microsoft/ts-command-line@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ts-command-line/-/ts-command-line-4.3.2.tgz#87341de2e24f279259297ebd38530300a9f97bc3"
+  integrity sha512-2QeyilabCe6IpBylPXuY6dCA1S9ym3Ii0zakXVPpyfjSj1NesnyuUeuh6e8kyIqzqJ+3LYjfPG63XzUBtwGqqw==
+  dependencies:
+    "@types/argparse" "1.0.33"
+    argparse "~1.0.9"
+    colors "~1.2.1"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -763,6 +772,11 @@
   dependencies:
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
+
+"@types/argparse@1.0.33":
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.33.tgz#2728669427cdd74a99e53c9f457ca2866a37c52d"
+  integrity sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==
 
 "@types/body-parser@*":
   version "1.17.1"
@@ -990,7 +1004,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.7, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -1592,6 +1606,11 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+colors@~1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+  integrity sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"


### PR DESCRIPTION
I decided to use this [@microsoft/ts-command-line](https://www.npmjs.com/package/@microsoft/ts-command-line) package to provide CLI argument parsing for the `deploy-to-heroku.ts` script but I'm not sure if it's a good fit.  The library seems to be geared primarily to tools like `git` that have a bunch of subcommands, which isn't really how the deployer script works right now.  The API for defining arguments also feels kind of verbose.
