### PR TITLE
Add basic NYCDB integration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,9 @@ PDFTOTEXT=
 # This is your Postgres database URL (optional). See the README for more details.
 DATABASE_URL=
 
+# This is your NYCDB database URL (optional). See the README for more details.
+NYCDB_URL=
+
 # The AWS S3 bucket to store cached PDFs and other data in. If left unspecified,
 # a filesystem cache backend will be used.
 S3_BUCKET=

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ Now you can test your connection with:
 node dbtool.js test_connection
 ```
 
+## NYCDB integration
+
+You can also optionally integrate with [NYCDB][] to figure out what BBLs to run
+batch jobs on.
+
+To do this, define the `NYCDB_URL` environment variable and test your connection with:
+
+```
+node dbtool.js test_nycdb_connection
+```
+
+[NYCDB]: https://github.com/nycdb/nycdb
+
 ## Running tests
 
 Run tests via:

--- a/dbtool.ts
+++ b/dbtool.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import docopt from 'docopt';
-import { database } from './lib/db';
+import { databaseConnector, nycdbConnector } from './lib/db';
 
 dotenv.config();
 
@@ -9,11 +9,13 @@ const VERSION = '0.0.1';
 const DOC = `
 Usage:
   dbtool.js test_connection
+  dbtool.js test_nycdb_connection
   dbtool.js -h | --help
 `;
 
 type CommandOptions = {
-  test_connection: boolean
+  test_connection: boolean;
+  test_nycdb_connection: boolean;
 };
 
 async function main() {
@@ -21,11 +23,24 @@ async function main() {
 
   if (options.test_connection) {
     await testConnection();
+  } else if (options.test_nycdb_connection) {
+    await testNycdbConnection();
   }
 }
 
+async function testNycdbConnection() {
+  const nycdb = nycdbConnector.get();
+  const table = 'hpd_registrations';
+  const bbls: {count: number} = await nycdb.one(`SELECT COUNT(DISTINCT bbl) FROM ${table};`);
+
+  console.log(`Found ${Intl.NumberFormat().format(bbls.count)} unique BBLs in ${table} table.`);
+  console.log(`Your NYCDB connection seems to be working!`);
+
+  await nycdb.$pool.end();
+}
+
 async function testConnection() {
-  const db = database.get();
+  const db = databaseConnector.get();
 
   const tables = await db.any('SELECT * FROM pg_tables;');
 

--- a/dbtool.ts
+++ b/dbtool.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import docopt from 'docopt';
-import { getDatabase } from './lib/db';
+import { database } from './lib/db';
 
 dotenv.config();
 
@@ -25,7 +25,7 @@ async function main() {
 }
 
 async function testConnection() {
-  const db = getDatabase();
+  const db = database.get();
 
   const tables = await db.any('SELECT * FROM pg_tables;');
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -22,6 +22,6 @@ class DbSingleton {
   }
 }
 
-export const database = new DbSingleton('DATABASE_URL');
+export const databaseConnector = new DbSingleton('DATABASE_URL');
 
-export const nycdb = new DbSingleton('NYCDB_URL');
+export const nycdbConnector = new DbSingleton('NYCDB_URL');

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,19 +1,27 @@
 import pgPromise from 'pg-promise';
 
-let db: pgPromise.IDatabase<{}>|null = null;
+class DbSingleton {
+  private db: pgPromise.IDatabase<{}>|null = null;
 
-export function getDatabase() {
-  if (!db) {
-    const DATABASE_URL = process.env.DATABASE_URL;
-
-    if (!DATABASE_URL) {
-      throw new Error('Please define DATABASE_URL in your environment!');
-    }
-
-    const pgp = pgPromise({});
-
-    db = pgp(DATABASE_URL);
+  constructor(readonly envVar: string) {
   }
 
-  return db;
+  get() {
+    if (!this.db) {
+      const url = process.env[this.envVar];
+
+      if (!url) {
+        throw new Error(`Please define ${this.envVar} in your environment!`);
+      }
+
+      const pgp = pgPromise({});
+      this.db = pgp(url);
+    }
+
+    return this.db;
+  }
 }
+
+export const database = new DbSingleton('DATABASE_URL');
+
+export const nycdb = new DbSingleton('NYCDB_URL');


### PR DESCRIPTION
This builds on #6 by providing connectivity to NYCDB, so we can easily fetch a list of BBLs to scrape.