### PR TITLE
Add --only-soa, --only-nopv options to scraper.

### DIFF
--- a/doffer.ts
+++ b/doffer.ts
@@ -66,6 +66,8 @@ export class PageGetter {
     if (!this.bbl || this.bbl.toString() !== bbl.toString()) {
       this.bbl = bbl;
       if (!await searchForBBL(this.page, this.bbl, this.log)) {
+        // NOTE: Do not change this error message, we currently search for
+        // it in SQL queries in dbtool.ts!
         throw new Error(`DOF property page for BBL ${this.bbl} does not exist`);
       }
     }
@@ -123,7 +125,7 @@ async function cachedGeoSearch(text: string, cache: DOFCache, log: Log = default
   });
 }
 
-export type linkFilter = (link: {date: string}) => boolean;
+export type linkFilter = (link: {kind: 'soa'|'nopv', date: string}) => boolean;
 
 export const defaultLinkFilter: linkFilter = () => true;
 

--- a/lib/dof.ts
+++ b/lib/dof.ts
@@ -102,6 +102,7 @@ export async function gotoSidebarLink(page: puppeteer.Page, name: SidebarLinkNam
 
 /** Represents a link to a Notice of Property Value PDF. */
 export type NOPVLink = {
+  kind: 'nopv',
   /** The period, e.g. "Revised 2015 - 2016". */
   period: string,
   /** The statement date in ISO format, e.g. "2016-01-02". */
@@ -128,7 +129,7 @@ export function parseNOPVLinks(html: string): NOPVLink[] {
     const date = parseDate($(link).text().trim());
     const url = link.attribs['href'];
     if (!date || !url) return;
-    links.push({period, date: getISODate(date), url});
+    links.push({kind: 'nopv', period, date: getISODate(date), url});
   });
 
   return links;
@@ -136,6 +137,7 @@ export function parseNOPVLinks(html: string): NOPVLink[] {
 
 /** Represents a link to a Statement of Account (SOA) PDF. */
 export type SOALink = {
+  kind: 'soa',
   /** The period, e.g. "2018-2019". */
   period: string,
   /** The statement quarter (1-4). */
@@ -167,7 +169,7 @@ export function parseSOALinks(html: string): SOALink[] {
     const date = parseDate(match[2].trim());
     const url = link.attribs['href'];
     if (!date || !url) return;
-    links.push({period, quarter, date: getISODate(date), url});
+    links.push({kind: 'soa', period, quarter, date: getISODate(date), url});
   });
 
   return links;

--- a/test/dof.test.ts
+++ b/test/dof.test.ts
@@ -4,13 +4,20 @@ import { expect } from 'chai';
 
 import { parseNOPVLinks, parseSOALinks } from '../lib/dof';
 
+// Change this temporarily to update snapshots.
+const REWRITE_SNAPSHOTS = false;
+
 function getHTML(filename: string): string {
   return fs.readFileSync(path.join(__dirname, 'html', filename), 'utf-8');
 }
 
 function ensureEqualJSON(object: any, filename: string) {
   const actual = JSON.parse(JSON.stringify(object));
-  const expected = JSON.parse(fs.readFileSync(path.join(__dirname, 'json', filename), 'utf-8'));
+  const snapshot = path.join(__dirname, 'json', filename);
+  if (REWRITE_SNAPSHOTS) {
+    fs.writeFileSync(snapshot, JSON.stringify(object, null, 2), { encoding: 'utf-8' });
+  }
+  const expected = JSON.parse(fs.readFileSync(snapshot, 'utf-8'));
   expect(actual).to.deep.equal(expected);
 }
 

--- a/test/json/example_nopv.json
+++ b/test/json/example_nopv.json
@@ -1,62 +1,74 @@
 [
-    {
-      "period": "2019 - 2020",
-      "date": "2019-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20190115&stmtType=NPV"
-    },
-    {
-      "period": "2018 - 2019",
-      "date": "2018-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180115&stmtType=NPV"
-    },
-    {
-      "period": "Revised 2017 - 2018",
-      "date": "2017-02-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170215&stmtType=NRV"
-    },
-    {
-      "period": "2017 - 2018",
-      "date": "2017-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170115&stmtType=NPV"
-    },
-    {
-      "period": "2016 - 2017",
-      "date": "2016-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160115&stmtType=NPV"
-    },
-    {
-      "period": "Revised 2015 - 2016",
-      "date": "2015-02-19",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150219&stmtType=NRV"
-    },
-    {
-      "period": "2015 - 2016",
-      "date": "2015-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150115&stmtType=NPV"
-    },
-    {
-      "period": "2014 - 2015",
-      "date": "2014-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140115&stmtType=NPV"
-    },
-    {
-      "period": "2013 - 2014",
-      "date": "2013-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130115&stmtType=NPV"
-    },
-    {
-      "period": "2012 - 2013",
-      "date": "2012-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120115&stmtType=NPV"
-    },
-    {
-      "period": "2011 - 2012",
-      "date": "2011-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110115&stmtType=NPV"
-    },
-    {
-      "period": "2010 - 2011",
-      "date": "2010-01-15",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100115&stmtType=NPV"
-    }
-  ]
+  {
+    "kind": "nopv",
+    "period": "2019 - 2020",
+    "date": "2019-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20190115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2018 - 2019",
+    "date": "2018-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "Revised 2017 - 2018",
+    "date": "2017-02-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170215&stmtType=NRV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2017 - 2018",
+    "date": "2017-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2016 - 2017",
+    "date": "2016-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "Revised 2015 - 2016",
+    "date": "2015-02-19",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150219&stmtType=NRV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2015 - 2016",
+    "date": "2015-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2014 - 2015",
+    "date": "2014-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2013 - 2014",
+    "date": "2013-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2012 - 2013",
+    "date": "2012-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2011 - 2012",
+    "date": "2011-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110115&stmtType=NPV"
+  },
+  {
+    "kind": "nopv",
+    "period": "2010 - 2011",
+    "date": "2010-01-15",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100115&stmtType=NPV"
+  }
+]

--- a/test/json/example_soa.json
+++ b/test/json/example_soa.json
@@ -1,254 +1,296 @@
 [
-    {
-      "period": "2019-2020",
-      "quarter": 2,
-      "date": "2019-08-29",
-      "url": "https://a836-edms.nyc.gov/dctm-rest/repositories/dofedmspts/StatementSearch?bbl=3012380016&stmtDate=20190829&stmtType=SOA"
-    },
-    {
-      "period": "2019-2020",
-      "quarter": 1,
-      "date": "2019-06-05",
-      "url": "https://a836-edms.nyc.gov/dctm-rest/repositories/dofedmspts/StatementSearch?bbl=3012380016&stmtDate=20190605&stmtType=SOA"
-    },
-    {
-      "period": "2018-2019",
-      "quarter": 4,
-      "date": "2019-02-01",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20190201&stmtType=SOA"
-    },
-    {
-      "period": "2018-2019",
-      "quarter": 3,
-      "date": "2018-11-16",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20181116&stmtType=SOA"
-    },
-    {
-      "period": "2018-2019",
-      "quarter": 2,
-      "date": "2018-08-24",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180824&stmtType=SOA"
-    },
-    {
-      "period": "2018-2019",
-      "quarter": 1,
-      "date": "2018-06-01",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180601&stmtType=SOA"
-    },
-    {
-      "period": "2017-2018",
-      "quarter": 4,
-      "date": "2018-02-23",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180223&stmtType=SOA"
-    },
-    {
-      "period": "2017-2018",
-      "quarter": 3,
-      "date": "2017-11-17",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20171117&stmtType=SOA"
-    },
-    {
-      "period": "2017-2018",
-      "quarter": 2,
-      "date": "2017-08-25",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170825&stmtType=SOA"
-    },
-    {
-      "period": "2017-2018",
-      "quarter": 1,
-      "date": "2017-06-02",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170602&stmtType=SOA"
-    },
-    {
-      "period": "2016-2017",
-      "quarter": 4,
-      "date": "2017-02-24",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170224&stmtType=SOA"
-    },
-    {
-      "period": "2016-2017",
-      "quarter": 3,
-      "date": "2016-11-18",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20161118&stmtType=SOA"
-    },
-    {
-      "period": "2016-2017",
-      "quarter": 2,
-      "date": "2016-08-26",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160826&stmtType=SOA"
-    },
-    {
-      "period": "2016-2017",
-      "quarter": 1,
-      "date": "2016-06-03",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160603&stmtType=SOA"
-    },
-    {
-      "period": "2015-2016",
-      "quarter": 4,
-      "date": "2016-02-19",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160219&stmtType=SOA"
-    },
-    {
-      "period": "2015-2016",
-      "quarter": 3,
-      "date": "2015-11-20",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20151120&stmtType=SOA"
-    },
-    {
-      "period": "2015-2016",
-      "quarter": 2,
-      "date": "2015-08-21",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150821&stmtType=SOA"
-    },
-    {
-      "period": "2015-2016",
-      "quarter": 1,
-      "date": "2015-06-05",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150605&stmtType=SOA"
-    },
-    {
-      "period": "2014-2015",
-      "quarter": 4,
-      "date": "2015-02-20",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150220&stmtType=SOA"
-    },
-    {
-      "period": "2014-2015",
-      "quarter": 3,
-      "date": "2014-11-21",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20141121&stmtType=SOA"
-    },
-    {
-      "period": "2014-2015",
-      "quarter": 2,
-      "date": "2014-08-22",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140822&stmtType=SOA"
-    },
-    {
-      "period": "2014-2015",
-      "quarter": 1,
-      "date": "2014-06-06",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140606&stmtType=SOA"
-    },
-    {
-      "period": "2013-2014",
-      "quarter": 4,
-      "date": "2014-02-21",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140221&stmtType=SOA"
-    },
-    {
-      "period": "2013-2014",
-      "quarter": 3,
-      "date": "2013-11-22",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20131122&stmtType=SOA"
-    },
-    {
-      "period": "2013-2014",
-      "quarter": 2,
-      "date": "2013-08-23",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130823&stmtType=SOA"
-    },
-    {
-      "period": "2013-2014",
-      "quarter": 1,
-      "date": "2013-06-07",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130607&stmtType=SOA"
-    },
-    {
-      "period": "2012-2013",
-      "quarter": 4,
-      "date": "2013-02-22",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130222&stmtType=SOA"
-    },
-    {
-      "period": "2012-2013",
-      "quarter": 3,
-      "date": "2012-11-30",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20121130&stmtType=SOA"
-    },
-    {
-      "period": "2012-2013",
-      "quarter": 2,
-      "date": "2012-08-17",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120817&stmtType=SOA"
-    },
-    {
-      "period": "2012-2013",
-      "quarter": 1,
-      "date": "2012-06-08",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120608&stmtType=SOA"
-    },
-    {
-      "period": "2011-2012",
-      "quarter": 4,
-      "date": "2012-02-24",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120224&stmtType=SOA"
-    },
-    {
-      "period": "2011-2012",
-      "quarter": 3,
-      "date": "2011-11-18",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20111118&stmtType=SOA"
-    },
-    {
-      "period": "2011-2012",
-      "quarter": 2,
-      "date": "2011-08-26",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110826&stmtType=SOA"
-    },
-    {
-      "period": "2011-2012",
-      "quarter": 1,
-      "date": "2011-06-10",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110610&stmtType=SOA"
-    },
-    {
-      "period": "2010-2011",
-      "quarter": 4,
-      "date": "2011-02-18",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110218&stmtType=SOA"
-    },
-    {
-      "period": "2010-2011",
-      "quarter": 3,
-      "date": "2010-11-19",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20101119&stmtType=SOA"
-    },
-    {
-      "period": "2010-2011",
-      "quarter": 2,
-      "date": "2010-08-27",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100827&stmtType=SOA"
-    },
-    {
-      "period": "2010-2011",
-      "quarter": 1,
-      "date": "2010-06-11",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100611&stmtType=SOA"
-    },
-    {
-      "period": "2009-2010",
-      "quarter": 4,
-      "date": "2010-02-26",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100226&stmtType=SOA"
-    },
-    {
-      "period": "2009-2010",
-      "quarter": 3,
-      "date": "2009-11-20",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20091120&stmtType=SOA"
-    },
-    {
-      "period": "2009-2010",
-      "quarter": 2,
-      "date": "2009-08-28",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20090828&stmtType=SOA"
-    },
-    {
-      "period": "2009-2010",
-      "quarter": 1,
-      "date": "2009-06-06",
-      "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20090606&stmtType=SOA"
-    }
-  ]
+  {
+    "kind": "soa",
+    "period": "2019-2020",
+    "quarter": 2,
+    "date": "2019-08-29",
+    "url": "https://a836-edms.nyc.gov/dctm-rest/repositories/dofedmspts/StatementSearch?bbl=3012380016&stmtDate=20190829&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2019-2020",
+    "quarter": 1,
+    "date": "2019-06-05",
+    "url": "https://a836-edms.nyc.gov/dctm-rest/repositories/dofedmspts/StatementSearch?bbl=3012380016&stmtDate=20190605&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2018-2019",
+    "quarter": 4,
+    "date": "2019-02-01",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20190201&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2018-2019",
+    "quarter": 3,
+    "date": "2018-11-16",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20181116&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2018-2019",
+    "quarter": 2,
+    "date": "2018-08-24",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180824&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2018-2019",
+    "quarter": 1,
+    "date": "2018-06-01",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180601&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2017-2018",
+    "quarter": 4,
+    "date": "2018-02-23",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20180223&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2017-2018",
+    "quarter": 3,
+    "date": "2017-11-17",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20171117&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2017-2018",
+    "quarter": 2,
+    "date": "2017-08-25",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170825&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2017-2018",
+    "quarter": 1,
+    "date": "2017-06-02",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170602&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2016-2017",
+    "quarter": 4,
+    "date": "2017-02-24",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20170224&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2016-2017",
+    "quarter": 3,
+    "date": "2016-11-18",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20161118&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2016-2017",
+    "quarter": 2,
+    "date": "2016-08-26",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160826&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2016-2017",
+    "quarter": 1,
+    "date": "2016-06-03",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160603&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2015-2016",
+    "quarter": 4,
+    "date": "2016-02-19",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20160219&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2015-2016",
+    "quarter": 3,
+    "date": "2015-11-20",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20151120&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2015-2016",
+    "quarter": 2,
+    "date": "2015-08-21",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150821&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2015-2016",
+    "quarter": 1,
+    "date": "2015-06-05",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150605&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2014-2015",
+    "quarter": 4,
+    "date": "2015-02-20",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20150220&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2014-2015",
+    "quarter": 3,
+    "date": "2014-11-21",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20141121&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2014-2015",
+    "quarter": 2,
+    "date": "2014-08-22",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140822&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2014-2015",
+    "quarter": 1,
+    "date": "2014-06-06",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140606&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2013-2014",
+    "quarter": 4,
+    "date": "2014-02-21",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20140221&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2013-2014",
+    "quarter": 3,
+    "date": "2013-11-22",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20131122&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2013-2014",
+    "quarter": 2,
+    "date": "2013-08-23",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130823&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2013-2014",
+    "quarter": 1,
+    "date": "2013-06-07",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130607&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2012-2013",
+    "quarter": 4,
+    "date": "2013-02-22",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20130222&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2012-2013",
+    "quarter": 3,
+    "date": "2012-11-30",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20121130&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2012-2013",
+    "quarter": 2,
+    "date": "2012-08-17",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120817&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2012-2013",
+    "quarter": 1,
+    "date": "2012-06-08",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120608&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2011-2012",
+    "quarter": 4,
+    "date": "2012-02-24",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20120224&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2011-2012",
+    "quarter": 3,
+    "date": "2011-11-18",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20111118&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2011-2012",
+    "quarter": 2,
+    "date": "2011-08-26",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110826&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2011-2012",
+    "quarter": 1,
+    "date": "2011-06-10",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110610&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2010-2011",
+    "quarter": 4,
+    "date": "2011-02-18",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20110218&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2010-2011",
+    "quarter": 3,
+    "date": "2010-11-19",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20101119&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2010-2011",
+    "quarter": 2,
+    "date": "2010-08-27",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100827&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2010-2011",
+    "quarter": 1,
+    "date": "2010-06-11",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100611&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2009-2010",
+    "quarter": 4,
+    "date": "2010-02-26",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20100226&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2009-2010",
+    "quarter": 3,
+    "date": "2009-11-20",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20091120&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2009-2010",
+    "quarter": 2,
+    "date": "2009-08-28",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20090828&stmtType=SOA"
+  },
+  {
+    "kind": "soa",
+    "period": "2009-2010",
+    "quarter": 1,
+    "date": "2009-06-06",
+    "url": "https://a836-mspuvw-dofptsz.nyc.gov/PTSCM/StatementSearch?bbl=3012380016&stmtDate=20090606&stmtType=SOA"
+  }
+]


### PR DESCRIPTION
Because the DOF site currently times out on NOPV statements (???) this adds options to `dbtool` that only download NOPV or SOA statements.

This also modifies the `clear_scraping_errors` command to _not_ clear errors caused due to DOF searches for BBLs explicitly containing "your search did not find any records" messages.
