### PR TITLE
Add --concurrency and --no-browser options.

### DIFF
--- a/doffer.ts
+++ b/doffer.ts
@@ -47,10 +47,13 @@ export class PageGetter {
   private bbl: BBL|null = null;
   private pagesRetrieved: number = 0;
 
-  constructor(readonly log: Log = defaultLog) {
+  constructor(readonly log: Log = defaultLog, readonly useBrowser = true) {
   }
 
   async getPage(bbl: BBL, linkName: SidebarLinkName): Promise<string> {
+    if (!this.useBrowser) {
+      throw new Error(`PageGetter is configured to not use browser`);
+    }
     if (this.pagesRetrieved >= PAGES_UNTIL_BROWSER_RESTART) {
       // Hopefully this will avoid errors like
       // "Error: Protocol error (Page.navigate): Session closed. Most likely the page has been closed."

--- a/lib/cache-s3.ts
+++ b/lib/cache-s3.ts
@@ -51,7 +51,15 @@ export class S3CacheBackend implements DOFCacheBackend<Buffer> {
       ContentLength: value.length,
       ...getS3PutObjectInputForKey(key),
     });
-    await this.client.send(putObjectCmd);
+    const result = await this.client.send(putObjectCmd);
+
+    // I have absolutely no idea why this method wouldn't throw if it failed,
+    // but a whole scrape job didn't fully write to S3 for some reason so
+    // we'll double-check this.
+    const status = result.$metadata.httpStatusCode;
+    if (status !== 200) {
+      throw new Error(`Write failed with HTTP ${status}`);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha": "^6.2.0"
   },
   "dependencies": {
-    "@aws-sdk/client-s3-node": "^0.1.0-preview.2",
+    "@aws-sdk/client-s3-node": "^0.1.0-preview.6",
     "@types/cheerio": "^0.22.13",
     "@types/docopt": "^0.6.31",
     "@types/dotenv": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,153 +2,154 @@
 # yarn lockfile v1
 
 
-"@aws-sdk/abort-controller@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.5.tgz#2e1a1db3c0992dcca3b11198cdaf4206498ab0c4"
-  integrity sha512-+TqAh6bzof5l+5tOND9YTEJEVeMli518ignGbLlB8CuMMeNPtvjXg6lzf5+XQpNXZ8CCmjqxZ2X5i1mImdJtmw==
+"@aws-sdk/abort-controller@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-0.1.0-preview.7.tgz#3129f4b98e6e3c435ef15f8293330a2db135e2f4"
+  integrity sha512-UpAa0PQ4u1UdDYPU9ajO/vzfmSn3rTMjXQjlsd0Ue4oK/A2lffNN28+egMVuS+Ivs96pv1HAfA4t4tPw+U6wjA==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/apply-body-checksum-middleware@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/apply-body-checksum-middleware/-/apply-body-checksum-middleware-0.1.0-preview.5.tgz#4b6ecd5715408d847b6e05497c84da3ee2114b3f"
-  integrity sha512-jSaptiE/JgE6437X5okUyMOw/5gtNCnQsRpIK3eYxbOi4x1F+GbFgpB30mwDh/wClS1bSHl4DoE/pe8Te4d5MQ==
+"@aws-sdk/apply-body-checksum-middleware@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/apply-body-checksum-middleware/-/apply-body-checksum-middleware-0.1.0-preview.7.tgz#3ac899bb5a5f17ed884c7fd02f43a8bf212f2c2d"
+  integrity sha512-ll6dvthNF9/mi9+78tDXbQS4Jzabf8ZUUhMveuMhTJgQkDLnigJW4gSOyGbNnkbRHgiESOSmBf4FDF0P39PkNQ==
   dependencies:
     "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/bucket-endpoint-middleware@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/bucket-endpoint-middleware/-/bucket-endpoint-middleware-0.1.0-preview.5.tgz#b1b43fb191a92f14d47b6bbb79989128c8d7e51d"
-  integrity sha512-z6BvmYdXppREN9DweWjvZa7ZthhIVp9ElU3BBSwRcjYLrT/t2t7acYeYUlxR6qj+k01cbDdqPw0qG2iS2bDRKA==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/client-s3-node@^0.1.0-preview.2":
-  version "0.1.0-preview.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3-node/-/client-s3-node-0.1.0-preview.2.tgz#9e56e94e9cf0e49ee9616d66f5a489255ee95226"
-  integrity sha512-sQj8KnijskzIijl/ETJpoygcN4o0AKBtZtXp6eiJjhLZf1RAX33Bd1QzSgScfElY/XVAMgntzWWvBm8VhUu+cQ==
-  dependencies:
-    "@aws-sdk/apply-body-checksum-middleware" "^0.1.0-preview.4"
-    "@aws-sdk/bucket-endpoint-middleware" "^0.1.0-preview.4"
-    "@aws-sdk/config-resolver" "^0.1.0-preview.4"
-    "@aws-sdk/core-handler" "^0.1.0-preview.4"
-    "@aws-sdk/credential-provider-node" "^0.1.0-preview.5"
-    "@aws-sdk/hash-node" "^0.1.0-preview.4"
-    "@aws-sdk/hash-stream-node" "^0.1.0-preview.5"
-    "@aws-sdk/location-constraint-middleware" "^0.1.0-preview.4"
-    "@aws-sdk/middleware-content-length" "^0.1.0-preview.4"
-    "@aws-sdk/middleware-expect-continue" "^0.1.0-preview.4"
-    "@aws-sdk/middleware-header-default" "^0.1.0-preview.4"
-    "@aws-sdk/middleware-serializer" "^0.1.0-preview.4"
-    "@aws-sdk/middleware-stack" "^0.1.0-preview.5"
-    "@aws-sdk/node-http-handler" "^0.1.0-preview.5"
-    "@aws-sdk/protocol-rest" "^0.1.0-preview.6"
-    "@aws-sdk/query-error-unmarshaller" "^0.1.0-preview.5"
-    "@aws-sdk/region-provider" "^0.1.0-preview.4"
-    "@aws-sdk/retry-middleware" "^0.1.0-preview.4"
-    "@aws-sdk/s3-error-unmarshaller" "^0.1.0-preview.2"
-    "@aws-sdk/signature-v4" "^0.1.0-preview.5"
-    "@aws-sdk/signing-middleware" "^0.1.0-preview.5"
-    "@aws-sdk/ssec-middleware" "^0.1.0-preview.4"
-    "@aws-sdk/stream-collector-node" "^0.1.0-preview.4"
-    "@aws-sdk/types" "^0.1.0-preview.4"
-    "@aws-sdk/url-parser-node" "^0.1.0-preview.4"
-    "@aws-sdk/util-base64-node" "^0.1.0-preview.2"
-    "@aws-sdk/util-body-length-node" "^0.1.0-preview.3"
-    "@aws-sdk/util-user-agent-node" "^0.1.0-preview.5"
-    "@aws-sdk/util-utf8-node" "^0.1.0-preview.2"
-    "@aws-sdk/xml-body-builder" "^0.1.0-preview.4"
-    "@aws-sdk/xml-body-parser" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/config-resolver@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.5.tgz#9d3655f0ac694bcc23d7af6498909c87723c7322"
-  integrity sha512-hwhX4WfKpaW2zeISBo6TYlreN77yuWwYNQ8kVP+8PkWgVHzRp733c6VbxrcVAF35bVAhxQhFqoA9ZKv67OMiiw==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/core-handler@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.5.tgz#302fb3ee80dc89fddadbbb1ec5d4942112b7aba5"
-  integrity sha512-LnfJ9naOAMFh/0J7nZ1puT1H2AHHcFTdITJGAmoaejnmoN1G17IBui8aclZVKPbfnQJKwcK5nMiL5BUxUIxNsA==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-env@^0.1.0-preview.6":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.6.tgz#8ee0235da5f66e9bf4db672164265ee99a2dc147"
-  integrity sha512-x75/fs5mg6RONz5g9fY8jcUjn6tJ9Qfc1RfdNl/FjRza19zc/FGf0p86rt7uq6OF/8s9t0QnvAiH0ii03TFSPw==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.5"
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-imds@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.5.tgz#b0b67817db54988f5bf9ea3440cf7e7430514f2e"
-  integrity sha512-LSB2YjvVr3XqcvqxEfcRkN6qxXG/N0YrP3XIcb17NmJ5sqLQSDykCdOIONCX44FJ9coHpUXB6P10HtzzAghiNQ==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-ini@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.5.tgz#72936d13eb4828d6a0f6cf4097a30dab31c9c588"
-  integrity sha512-h5YljWR3QDVECJqWs78zKXjg8/zZTV2MYbSMx0UqKwijIWsa6yfH3+G+XLJdkW3ZbvsVo3zsppZixjL59o/t9Q==
-  dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.5"
-    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/credential-provider-node@^0.1.0-preview.5":
+"@aws-sdk/bucket-endpoint-middleware@^0.1.0-preview.7":
   version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.7.tgz#2d81d4278f44d43358d5ca20d5638c49825deba7"
-  integrity sha512-Fjnr8SyfUhWlREOnzpRS/Wk5loqf0L3z1fOP6aCDmViPlAfDzCF83F0EkIqeBqTgVhCu40wysCs31nTrV8pWiw==
+  resolved "https://registry.yarnpkg.com/@aws-sdk/bucket-endpoint-middleware/-/bucket-endpoint-middleware-0.1.0-preview.7.tgz#5322caabfcef9c8416b026bfc000c3a46b8b7e55"
+  integrity sha512-XUrR/fKADNTXgW5wfp0U2K2WD+4NiY/njne7rR0YTNZHE0eWD0q0YvRx4LXj6HFraAUqZ8liPG2k/BjzdT8M0Q==
   dependencies:
-    "@aws-sdk/credential-provider-env" "^0.1.0-preview.6"
-    "@aws-sdk/credential-provider-imds" "^0.1.0-preview.5"
-    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.5"
-    "@aws-sdk/credential-provider-process" "^0.1.0-preview.3"
-    "@aws-sdk/property-provider" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/credential-provider-process@^0.1.0-preview.3":
-  version "0.1.0-preview.3"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.3.tgz#2ea73b939cab1f1f5082bec9cc6332a2f7bfc0e6"
-  integrity sha512-HVoWom235BXMFBbVrGI4G1k4V/e0kxAbjKIQm37lvm9rWrRDw/b0+T/TFM8bGoKVHGX89bGWDQa0cFYktSldSg==
-  dependencies:
-    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.5"
-    "@aws-sdk/property-provider" "^0.1.0-preview.5"
-    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/hash-node@^0.1.0-preview.4":
+"@aws-sdk/client-s3-node@^0.1.0-preview.6":
   version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.6.tgz#39747bb77f107988af25fd2a8f2b09383f1d6bb3"
-  integrity sha512-XGolfAQrNQzUwsiS24G1q0f/7Puwi7LZFlsGph+llMXt+aD6p9ROYDpRpZjHtL/VSwBWHUQYIv+ZQWrl5wkbig==
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3-node/-/client-s3-node-0.1.0-preview.6.tgz#a2ffeba6b9c89a394730d3c9c916a484c628269c"
+  integrity sha512-bvXiiHGBQ6+Zo7EaBd1Goo75TKKHMdOBXgmd5cV5/2TpVd3d7/pm9ig4E4HKbXnbGorb9Ne1qhh0WQ2lrgxVdA==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/apply-body-checksum-middleware" "^0.1.0-preview.7"
+    "@aws-sdk/bucket-endpoint-middleware" "^0.1.0-preview.7"
+    "@aws-sdk/config-resolver" "^0.1.0-preview.7"
+    "@aws-sdk/core-handler" "^0.1.0-preview.7"
+    "@aws-sdk/credential-provider-node" "^0.1.0-preview.9"
+    "@aws-sdk/hash-node" "^0.1.0-preview.8"
+    "@aws-sdk/hash-stream-node" "^0.1.0-preview.9"
+    "@aws-sdk/location-constraint-middleware" "^0.1.0-preview.7"
+    "@aws-sdk/middleware-content-length" "^0.1.0-preview.7"
+    "@aws-sdk/middleware-expect-continue" "^0.1.0-preview.7"
+    "@aws-sdk/middleware-header-default" "^0.1.0-preview.7"
+    "@aws-sdk/middleware-sdk-s3" "^0.1.0-preview.4"
+    "@aws-sdk/middleware-serializer" "^0.1.0-preview.7"
+    "@aws-sdk/middleware-stack" "^0.1.0-preview.8"
+    "@aws-sdk/node-http-handler" "^0.1.0-preview.8"
+    "@aws-sdk/protocol-rest" "^0.1.0-preview.9"
+    "@aws-sdk/query-error-unmarshaller" "^0.1.0-preview.8"
+    "@aws-sdk/region-provider" "^0.1.0-preview.7"
+    "@aws-sdk/retry-middleware" "^0.1.0-preview.7"
+    "@aws-sdk/s3-error-unmarshaller" "^0.1.0-preview.5"
+    "@aws-sdk/signature-v4" "^0.1.0-preview.9"
+    "@aws-sdk/signing-middleware" "^0.1.0-preview.9"
+    "@aws-sdk/ssec-middleware" "^0.1.0-preview.7"
+    "@aws-sdk/stream-collector-node" "^0.1.0-preview.8"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    "@aws-sdk/url-parser-node" "^0.1.0-preview.8"
+    "@aws-sdk/util-base64-node" "^0.1.0-preview.4"
+    "@aws-sdk/util-body-length-node" "^0.1.0-preview.5"
+    "@aws-sdk/util-user-agent-node" "^0.1.0-preview.9"
+    "@aws-sdk/util-utf8-node" "^0.1.0-preview.4"
+    "@aws-sdk/xml-body-builder" "^0.1.0-preview.7"
+    "@aws-sdk/xml-body-parser" "^0.1.0-preview.8"
+    tslib "^1.8.0"
+
+"@aws-sdk/config-resolver@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-0.1.0-preview.7.tgz#adb8077b3656cf7a890c6302c28f468665b76455"
+  integrity sha512-clP/NFkGyIJzCPPZ9y9vc4rQD2O8euuEVtYDlHNPfe+791uo43I1/qhw20v31mPY1OH0dScf5Jn/n4Ed9YO1VA==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/core-handler@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core-handler/-/core-handler-0.1.0-preview.7.tgz#2deb6e8a64a4138ebfe8c4337bd84f48a3fdbb0d"
+  integrity sha512-F+BAYmcPGbbK2w6Y9i4RgK9f8ojUuQKoZuFCxiYoujLGoak/p81gACTz3dQyV9/NiY46EvmdpyaGQeLtpfuriQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-env@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-0.1.0-preview.8.tgz#ea8d22964e6041e0bfffb4085a366c6ed5d76a28"
+  integrity sha512-wW2XRalzx8jAIsVSdOM4cDP3hgbvPy6UJhQwpn9N3kfb22G5FPEry6hlJKHAVzQ15tkTNd0C6SyRlXgC5zEzmA==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.7"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-imds@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-0.1.0-preview.7.tgz#47d0a7ac1f369e2ca353d8301ae842ca8aee0e15"
+  integrity sha512-FgrXEUf9/6VL+YWwGGpzVC7+hHcb43+kUtez/HoVq7duCi8OpnCAdLuGFoJdWhi2K76Qf1i3z2+fUYcSQnjcoQ==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-ini@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-0.1.0-preview.7.tgz#17691ba3ea7fcfe7923e2d109ba23485f3eab53a"
+  integrity sha512-iIVGZonHwy08RJgW9AZURKAbRTcBtwZw9wWSkO1YgtFVKYHH81E+C/k3o9ljCD9TK+XfvB2dv5alPkS71EufIQ==
+  dependencies:
+    "@aws-sdk/property-provider" "^0.1.0-preview.7"
+    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-node@^0.1.0-preview.9":
+  version "0.1.0-preview.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-0.1.0-preview.9.tgz#bbf27690a83f9772f73203514009d7c3ecc57e6d"
+  integrity sha512-l7AioIfRpNjgEe+8ikWUEFV8Z5eDMQTDl6BEG3y2O9K+rksSmYvIAkraOJjJmHPi/nTKgCXrWzoBpasYahuSvA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^0.1.0-preview.8"
+    "@aws-sdk/credential-provider-imds" "^0.1.0-preview.7"
+    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.7"
+    "@aws-sdk/credential-provider-process" "^0.1.0-preview.5"
+    "@aws-sdk/property-provider" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/credential-provider-process@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-0.1.0-preview.5.tgz#647c0afa0fc5e364ad956362b615ff40ba59e282"
+  integrity sha512-OIBmuaul/aF3w3oCc1zIw+jE5tlhacrhCD/LXf0DornF8Bfp4oaYA5qJ4Lttu/Q25s2qW5+YEuFlDsnqpIQUyw==
+  dependencies:
+    "@aws-sdk/credential-provider-ini" "^0.1.0-preview.7"
+    "@aws-sdk/property-provider" "^0.1.0-preview.7"
+    "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/hash-node@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-0.1.0-preview.8.tgz#7f6de5e60d1cf220aa548e2276fc24770efa5c03"
+  integrity sha512-tYBKE5ggAfw7oCLj3/jVJomruUMXhFOL+yH7xnKbgEjCi2m/jsSClCwjUbco2d5eFeC75t74RsFuyCREm9o+nw==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
     "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/hash-stream-node@^0.1.0-preview.5":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-0.1.0-preview.7.tgz#40f8fcaf6bbb330a622d02e21a9b5a48c3cb2338"
-  integrity sha512-jWm48PEhJ1CcpVbD1SjLUDtlrvcw/ONQ7x3GQ0Vu/reJY0FCgt1DwXoESCLuPrPe6o2ztNiYZid+2u6mES0Peg==
+"@aws-sdk/hash-stream-node@^0.1.0-preview.9":
+  version "0.1.0-preview.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-0.1.0-preview.9.tgz#b1ca2badf9c48199b7d726874f88f12fa2423b99"
+  integrity sha512-XV8vQgwrDV7VGoL94ry/HZsaw4wA6NDKynpsctr4yQfgWy3hunrMunngnIs3jybBlkyCuhmw2SssjEjSugpvFg==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/is-array-buffer@^0.1.0-preview.3":
@@ -165,157 +166,164 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/location-constraint-middleware@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/location-constraint-middleware/-/location-constraint-middleware-0.1.0-preview.5.tgz#ce83882339977ba4d60e183fc570057ca07c71a4"
-  integrity sha512-w6y2vzo5IaUQ6oE7gFvjcCMXyU2+Su6RJ4vOOqUjok+kZ1vgS9nll5FgdWEEWfQRB88dnBnQIuXeIa8DTTLXxg==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/middleware-content-length@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.5.tgz#7d8cbbb19d50d333e038510342da71534023c44e"
-  integrity sha512-T6IjQRTZyrFlvzYxihZBLsvHQ5EB3aMzXFsz7EcvJOBU9Y6btbG5gKOx7zN5lIsuv5+8+EpEIEA3QqR+PddvJg==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/middleware-expect-continue@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-0.1.0-preview.5.tgz#5dd9a496e380346fad8832d2e25882f22b4944b5"
-  integrity sha512-GJjlPyHoO05lOhQYuTnMA5+uayUQMNNV3zo2ktTiJ5ZyeSsstlBcJo80n1X5HhUi++PkkyC4Mumx+uJeGiTQvg==
-  dependencies:
-    "@aws-sdk/middleware-header-default" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/middleware-header-default@^0.1.0-preview.4", "@aws-sdk/middleware-header-default@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.5.tgz#89990a9c3f71d883531cb094727901af64dd1735"
-  integrity sha512-l0DYSuOrE/pRS93ziV+a47K78XY3EV5hNfr0mcbxh39c1Xh5MZe+jic1O9FeRfertOXZXCIAuHCnDf0ET/CKGQ==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/middleware-serializer@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.5.tgz#00a8355abc462679580d49969eea8c8513ce4208"
-  integrity sha512-iDPNjWmUz81FOj+23BX/6jpCUW/JWfeNWHaQcawa7jhMCcRmnBqHl9mEvQLz8xT0qmZRXcOUPx1/P6Aebi+hoQ==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/middleware-stack@^0.1.0-preview.5":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.6.tgz#683a308eb95ac6170c7181fd2c96e6f73da7e5cc"
-  integrity sha512-Zkj6MkRFS9f+VZye8QZU8Yd2tkv3pCCY1CtRmrDiFQ2fAXAWuMHHJ/aHA8norlVXE7409i+hRLLTRftupYU55Q==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/node-http-handler@^0.1.0-preview.5":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.6.tgz#053b41a1fbb3d678ea0427e9b1120c808d0efbe1"
-  integrity sha512-40ZygkGi1YQ1y8weda2sUu+oXiiPfMEjiFRNE8tvT8gUgYnwv6RYECTeDKz7QM/wjVL/6dNOVLWl7tP0iwBGww==
-  dependencies:
-    "@aws-sdk/abort-controller" "^0.1.0-preview.5"
-    "@aws-sdk/querystring-builder" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/property-provider@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.5.tgz#7900d1c2acf070bfbe790304e159dbe72f7d1e74"
-  integrity sha512-1jqqNKbX5GFL/zVrMh+5YOsM4eBlvl46eaFVH+lK6sAUhw3DmigrTvrIb7WPt0ZJYYbzyOM+VL94+kaHItbT4A==
-  dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/protocol-rest@^0.1.0-preview.6":
+"@aws-sdk/location-constraint-middleware@^0.1.0-preview.7":
   version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-rest/-/protocol-rest-0.1.0-preview.7.tgz#dfcc125d66ea35854b0a28998ad521b098318669"
-  integrity sha512-pAhcaiAxhjalp+5P2zLbrqeNKwfbtGhlusCtwui5TP8ogphpATjn2uEAbDBtARv0wBrrNOF/8eNJlt+o4snE0w==
+  resolved "https://registry.yarnpkg.com/@aws-sdk/location-constraint-middleware/-/location-constraint-middleware-0.1.0-preview.7.tgz#0ae88632dc37187b95242e8a0370b345745b3a48"
+  integrity sha512-K7EZ77oSVqyrTDZKJ8OQ7m1/EAEoRFUknE0HsiTRImhRHqxPhR+sP6brWU+gdywgYbDVaXJox30GUMNAOqhs9Q==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-content-length@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-0.1.0-preview.7.tgz#3e873c6886c737e02282f3507daa3348d85a368c"
+  integrity sha512-6ZI+dY8VgWmKL48tBtFGFgllwdhKgqNztscLtYPmHl38zrz4sITJnyGwbYDGLW+xLIGDOQhyFd/6kWTqT9QyKQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-expect-continue@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-0.1.0-preview.7.tgz#77acc2bbdad49167a2b9442655545da082f022c3"
+  integrity sha512-Yk6TFiOloQwIgsr46uaQbBIl75AbjiM8hbljexSKmipfXz/Il8EK61Pe9MrLpIUtj7+wDnj35/fCwi3kX0jBHQ==
+  dependencies:
+    "@aws-sdk/middleware-header-default" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-header-default@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-header-default/-/middleware-header-default-0.1.0-preview.7.tgz#3083c6ed8dfa3c9d556941011b388789b84eb2cc"
+  integrity sha512-hf7+YMiPnyzRKzmcZZ5v2NKkC6CKgo8nnckJ1A1OlvWYGq3hLMF1gKDMzdkEFjWJmDWv6AVNyHjw5qe4AV8LVA==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-sdk-s3@^0.1.0-preview.4":
+  version "0.1.0-preview.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-0.1.0-preview.4.tgz#7a460aae70fa3c77d41c969d8c8c64453fff1fe4"
+  integrity sha512-osWs7dGmwFv/edBfjZ2w034+0L4GAigvn4b5yrpuBe64gDvTz+AIvl9us3XnTXvism0QH1P3vmEvjims/D1Zrg==
+  dependencies:
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-serializer@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serializer/-/middleware-serializer-0.1.0-preview.7.tgz#7d4ed3d16b47f12f7ed0762ff9594c0f2da9c96c"
+  integrity sha512-mc5xBnrdDM9k3a78cbTSw+VWTadpDQQBObSuAy4fCxrkPZa+APqRY+y9MMDQ0uWI80e6Ab1pt9wTx1/OM1uMWQ==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/middleware-stack@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-0.1.0-preview.8.tgz#9a2e2fc3e1e7a6e393d40d4f91f43a8d3f68a1cd"
+  integrity sha512-dlcq80vQe5buIVlAyPjJE0uL21IPfr04j5catPIfQ9rBm4809pib7vJoUkjNrfCk+RTeeVgynVdSdUaxlF5oWw==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/node-http-handler@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-0.1.0-preview.8.tgz#d301ca5bd7996ab5cb0d29f595aa37e6815e4b25"
+  integrity sha512-D3hISgch64L2rG8RQDi361ywoSgsyH/5Yj4ZF05ZCo8UZ8TjU1CtiLPKy1is0XLqojhLlDAQ65lNna44xoArcw==
+  dependencies:
+    "@aws-sdk/abort-controller" "^0.1.0-preview.7"
+    "@aws-sdk/querystring-builder" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/property-provider@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-0.1.0-preview.7.tgz#21ddb9b5f66403310f52ac7f286a9e6bc178f8c7"
+  integrity sha512-8yKkR78XC3fvdd+ePohfLuZHKBL7e3k+t82JL775phiXO94WHiz/hlvm6tGhNz5zKzz72yLrJPCyoQAZLrxrTg==
+  dependencies:
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/protocol-rest@^0.1.0-preview.9":
+  version "0.1.0-preview.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-rest/-/protocol-rest-0.1.0-preview.9.tgz#6b77492f2cd1fad9ad3c1656d8b12c095bc9af1d"
+  integrity sha512-ozNKq4+1+mYcJCEmNMrcnFmm9pqQ5jvWol9NQWpmtxIsOpuTvQd0N3ekscehjvztZwJ7vFyNaftQbWhBZdVO/A==
   dependencies:
     "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
     "@aws-sdk/is-iterable" "^0.1.0-preview.3"
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
-    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.6"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    "@aws-sdk/util-error-constructor" "^0.1.0-preview.5"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
+    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.8"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    "@aws-sdk/util-error-constructor" "^0.1.0-preview.7"
     "@aws-sdk/util-uri-escape" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/protocol-timestamp@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-timestamp/-/protocol-timestamp-0.1.0-preview.5.tgz#7805d40558a26c12a4b33c4103db179beaa9d77c"
-  integrity sha512-HYbENtsxUlkyxf5tpD/5HI4MlsRvjhhMW08SsUdD+EApNyITGItPaDhK335D4ijjpLQCSHvUgA0rl+IRr1WawA==
+"@aws-sdk/protocol-timestamp@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-timestamp/-/protocol-timestamp-0.1.0-preview.7.tgz#294753a16e79d167df7f12a64aa7d34efcd73e86"
+  integrity sha512-ObO202v456/S6Ckhlu844KBXN9toFTPt8zzrJpESzntVXIaidDECetd120/xToycYmICinvAYH9o1E2l6VlCRQ==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/query-error-unmarshaller@^0.1.0-preview.5":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.6.tgz#e655f4b3983dc2af98c9b9b6d35ed9173dea0ccd"
-  integrity sha512-9OJbYYh4sCYMJQusQlmaoKGoz2Cg11cpOlauhmqkafzCHU8YsDHkCgqrlbIW4EvNyO29eWeblvYHdH7iJYSb/A==
+"@aws-sdk/query-error-unmarshaller@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/query-error-unmarshaller/-/query-error-unmarshaller-0.1.0-preview.8.tgz#bcee4a3adda59b63e21eee220f13b1be7ddb8549"
+  integrity sha512-41lNT9delFhOss5H3eoi/2wYLYFuVqLXutRb5ZM5VvdhE4ZG+L8oE8HM0LSwQBttQFHaZcjdx3x3n9EVatSuCw==
   dependencies:
-    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.6"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    "@aws-sdk/util-error-constructor" "^0.1.0-preview.5"
+    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.8"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    "@aws-sdk/util-error-constructor" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/querystring-builder@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-0.1.0-preview.5.tgz#d2028c51b3e0cfae4d2b3bea74927dfa70023db4"
-  integrity sha512-ZwA7m2E0GfO0sEqinear8B/oZ3QyHLgPST6JLhwPYnpzB/ZzYPktp+aF/RCZ6S9OEeIC61L7lmwNsLTRFuOrDQ==
+"@aws-sdk/querystring-builder@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-0.1.0-preview.7.tgz#b5c0bd96415803483a724975d5a1aeb28c6aa422"
+  integrity sha512-U2d9CYTwnF4/Qc8XXFmCdRzcApTmwEXLyHUcjK2/GaOHKkHDAeIC94+cuP+H3nDjCjb3TdKV2xrl/wzuP0YBrg==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     "@aws-sdk/util-uri-escape" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/querystring-parser@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.5.tgz#4b1d943a8b1c9383993b9d4264ac1544c44840f8"
-  integrity sha512-dKuGB/BsaCQaCYraOQf9B7UZyd35Q3+QJEG45cmOs719wb07YTR4fd/mtsPBhle6RYi0NGVmIhsO2VGlAYRfBw==
+"@aws-sdk/querystring-parser@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-0.1.0-preview.7.tgz#4c485abcf241b6dd180f285da670a884ca4841dc"
+  integrity sha512-r72E/wZYrhTXTK950Ld/L2Loso/HDqExQkIuCn1Pu8Rx0+uC3Y8fQTx+JZd5M5kOniCpGKdHWGc7y/bH/tjH4A==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/region-provider@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.5.tgz#5384b48805675f0623141c4a9cb629f9b5ec617b"
-  integrity sha512-CkZWBvUi0NT4JQ1AiikTe4cck4PSks+beL4bEDwsUpEHO0OxP9d4Nr/eP0o3FB3+eJIwkDqMKYskhdVFcZ+AlA==
+"@aws-sdk/region-provider@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-provider/-/region-provider-0.1.0-preview.7.tgz#dcb5cd10c712ae54fac605c5b4f08a30131ea21c"
+  integrity sha512-n+LeuQYPYbCyfCboz9mmYqcPPKdmdd60KPbPeRqSdJYr9QZz9hWU962oCOl5EtLYIsUzy7Fm33APv6toEcAPVw==
   dependencies:
-    "@aws-sdk/property-provider" "^0.1.0-preview.5"
+    "@aws-sdk/property-provider" "^0.1.0-preview.7"
     "@aws-sdk/shared-ini-file-loader" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/response-metadata-extractor@^0.1.0-preview.5", "@aws-sdk/response-metadata-extractor@^0.1.0-preview.6":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.6.tgz#7a0ff8ccd679d066032ca1f79e04a2ea11f7f62d"
-  integrity sha512-p4d9jf7Oe6UwbJcwDw2Z0N3ZDCkWsoAnET+qwEcymeHBlx5nj0AM+Kc0hXKnWUiDsmftQKfJCwQ53WLb2fTo+Q==
+"@aws-sdk/response-metadata-extractor@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/response-metadata-extractor/-/response-metadata-extractor-0.1.0-preview.8.tgz#081e8737cdf77e18f7837b6c5a1df00563172001"
+  integrity sha512-c5aJGYDiEwWqYpsROCqrmR60d0yeVdvRtzMptcpCI95BvIizS3hTc+PfuOq3Gcz7L+EQysbzQyqZutCJ/zLbew==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/retry-middleware@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.5.tgz#f8d1466294ee18ceaa60e19a66e271af706288db"
-  integrity sha512-bxsY5LlUqrzqrGIJBDLjasiBzBzib+1fSLg6MR4DrYd9WmilnNKR+lmf592+enaR2K1DNdvmkfJz3CKl9HMZIg==
+"@aws-sdk/retry-middleware@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/retry-middleware/-/retry-middleware-0.1.0-preview.7.tgz#4923089c9a2c5306c91489fd7d041f70f4b597e2"
+  integrity sha512-ULiq+dffOPurjyHm95PYWi1Cy27LQg9jPwLz5tiL7oIla/j9b5bcclZE3n0RtqbHDUvWJL5kxmYw0Kjrggr5iw==
   dependencies:
     "@aws-sdk/service-error-classification" "^0.1.0-preview.3"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/s3-error-unmarshaller@^0.1.0-preview.2":
-  version "0.1.0-preview.2"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-error-unmarshaller/-/s3-error-unmarshaller-0.1.0-preview.2.tgz#c950b9c0a3d9395161b2d99d2d01e1d94835ecc0"
-  integrity sha512-3A6FUzFwGe34+1l8daxXaiTymZmb1LvVXNM+aapfJqRCM80vfbTEf+pzefIHCJAOhTCaSyhtkrs07iOpj3L1nw==
+"@aws-sdk/s3-error-unmarshaller@^0.1.0-preview.5":
+  version "0.1.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-error-unmarshaller/-/s3-error-unmarshaller-0.1.0-preview.5.tgz#c17ad7cda6cbde8647fdd3b19be51dedc1f81e0e"
+  integrity sha512-YrHm3qt0Y/k6d0qLDNOylRDAb15EN+0gxtlKo1CUMnlcy3UDi7VjiHbvFuMnkUgb3snXJy1Womj4XkkSznGBtA==
   dependencies:
-    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.4"
-    "@aws-sdk/util-error-constructor" "^0.1.0-preview.4"
+    "@aws-sdk/response-metadata-extractor" "^0.1.0-preview.8"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    "@aws-sdk/util-error-constructor" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/service-error-classification@^0.1.0-preview.3":
@@ -330,57 +338,57 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/signature-v4@^0.1.0-preview.5", "@aws-sdk/signature-v4@^0.1.0-preview.7":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.7.tgz#0c7c77e83b3178125742c53416f69ff86ab0855c"
-  integrity sha512-lVi1dJKEjKhNv88Ouo3UaZIintSHcaWGozI4JDwjGjaSsAg1WkkRS72Te6ur1+owJ0oHTcaXwzfQRjgX/qqTjA==
+"@aws-sdk/signature-v4@^0.1.0-preview.9":
+  version "0.1.0-preview.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-0.1.0-preview.9.tgz#8ff5dc3a794916266d2f6e1d6713966c0cdda9b3"
+  integrity sha512-772F+4Z3VHMQUIpdXmcg4Ar6ATiDQ+tLXdUQX/jDvkXbQWXURjZLLL6X1ghFSlXKmOR0fRxmYZL0fG/M9PwssQ==
   dependencies:
     "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     "@aws-sdk/util-hex-encoding" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/signing-middleware@^0.1.0-preview.5":
+"@aws-sdk/signing-middleware@^0.1.0-preview.9":
+  version "0.1.0-preview.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.9.tgz#174168dc189188d9a1fe9f1805197a48b9a25d32"
+  integrity sha512-XXrs0h5YTLgkviotIQSwYjAf0aTPKCFYPA0vYubTP1EY7fUGI3hLlFttaUh5/77h8b3RNYx/QFcRXodY5GAxWg==
+  dependencies:
+    "@aws-sdk/signature-v4" "^0.1.0-preview.9"
+    "@aws-sdk/types" "^0.1.0-preview.7"
+    tslib "^1.8.0"
+
+"@aws-sdk/ssec-middleware@^0.1.0-preview.7":
   version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/signing-middleware/-/signing-middleware-0.1.0-preview.7.tgz#55f3b5c4703fe7cd5999adbbd6629497588225fb"
-  integrity sha512-tmQcI3tdVMdxdOR8o17fHEyMRGepe8tEL+TPnvnD7TX0c8tkxZ+bHxRV9KU+s0DW+b2rWe7l+E1ytgS1tY04UA==
+  resolved "https://registry.yarnpkg.com/@aws-sdk/ssec-middleware/-/ssec-middleware-0.1.0-preview.7.tgz#ee97039089dc8511f584b3ff87067c4bf1537a80"
+  integrity sha512-mpM4kGC6CYJ8cdcSI8sBVZv0uGljt+FE2FfLvYL9qAssBgbp14po/aiAXJiPSSzqdZim375T6ht2nqrVSMD/zA==
   dependencies:
-    "@aws-sdk/signature-v4" "^0.1.0-preview.7"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/ssec-middleware@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/ssec-middleware/-/ssec-middleware-0.1.0-preview.5.tgz#30c1610b8ec739a0014e6415a504ae761aaa8440"
-  integrity sha512-x5Yy7Di+6BBmD3vMiq8irsAmSqVQdCNuK2Ka41PmmuYIf4MjZaTUkXnknXbnCCkkUyoUYrri/CQyUTqLksw19A==
+"@aws-sdk/stream-collector-node@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.8.tgz#5a748ff352bb75540b3e56bf2b7d51c4340b4c12"
+  integrity sha512-p8cpGYqUy0pgOsephImE4yar3CJqhuVgPqhegRQXXYor3ZPkGloPymNys/1FmVb4RbzLrQ8WmpM+Fd0dUIu3PA==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/stream-collector-node@^0.1.0-preview.4":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/stream-collector-node/-/stream-collector-node-0.1.0-preview.6.tgz#c3e3a14e3d622ae6133670cdb85ab122843c38ad"
-  integrity sha512-cmQfUMrBlm/vPXc9FpDyvI2n9MRgendGlQj9iSyR/DxmcNrf/yJoedSbfj7KzyfwFXmD2RB43rTgMoeXkYzpVQ==
+"@aws-sdk/types@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.7.tgz#2c3e8b911c9236e8f48d8ffb3c9df449a067df58"
+  integrity sha512-gpyU8N9XEs8diE4uW9B6/hjKDrB/c4a1GF4ICwkaGYpXrbJy9QLrEU8Hk4rC6P1l++YYyJKMl7RjMmTyBtNOzw==
+
+"@aws-sdk/url-parser-node@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.8.tgz#d8863b852777b86d21d5693d11cf211d1a69443f"
+  integrity sha512-h8YwL+mLTBPNzryREkLChhtRSdz70tOR9y/UB6PATGKoJbMUFoTsDY1jbJ4WWBfdKjphZy9xVWTyxoCkP07tQQ==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/querystring-parser" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/types@^0.1.0-preview.4", "@aws-sdk/types@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-0.1.0-preview.5.tgz#d55946b363a107a3c72063df37ecc8b208de30a6"
-  integrity sha512-U5YNVOtAOsilZrszHWr+fdAwXgOccbVbnXG9gq1nIOOVv89zn3SAj7x/E5QrbcAhKPtJedXvk17i6DCcJlPxhg==
-
-"@aws-sdk/url-parser-node@^0.1.0-preview.4":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser-node/-/url-parser-node-0.1.0-preview.6.tgz#d91fd6207841d713d85ed2bc519b6bce764c3bed"
-  integrity sha512-82d4bNcOUbHkrjX+dRvWnAsxoU5Ff+rstZHY2JWz2AgLXz+dlvurvmTewoPEb6ANmq3zQSqmHHXGzPFbjFt9SQ==
-  dependencies:
-    "@aws-sdk/querystring-parser" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
-    tslib "^1.8.0"
-
-"@aws-sdk/util-base64-node@^0.1.0-preview.2":
+"@aws-sdk/util-base64-node@^0.1.0-preview.4":
   version "0.1.0-preview.4"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-0.1.0-preview.4.tgz#17271a49874b96e1e7b842cb0c564a3a7260137f"
   integrity sha512-L9O3lMWB7y2xVIgg/nSJ7xZLVFmxMCk1maaup3CoL5USLqB7n7ngpf/WAH2LyhaGo8Og8TrAKt4BizpxbZU7wg==
@@ -388,7 +396,7 @@
     "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/util-body-length-node@^0.1.0-preview.3":
+"@aws-sdk/util-body-length-node@^0.1.0-preview.5":
   version "0.1.0-preview.5"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-0.1.0-preview.5.tgz#330628a9b6e56a7766f00c7ae5074e5090efdec5"
   integrity sha512-ZmqB7E/RizTe8ajxLyXdshoyzQg47CAkbnCK7yRE4A9N7XMEUgzyFVXuKT08DmbAwYSYWI5jaUwm3jpMKqG+bw==
@@ -403,12 +411,12 @@
     "@aws-sdk/is-array-buffer" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/util-error-constructor@^0.1.0-preview.4", "@aws-sdk/util-error-constructor@^0.1.0-preview.5":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-error-constructor/-/util-error-constructor-0.1.0-preview.5.tgz#d71ebd73cfec7e9160a8d701a488ceee6ca8c0ae"
-  integrity sha512-VT3DatjCLv5fkm8Q7Xslt50mN5ksWUminWzBv3bte2RWIG+zM8JfuO1UeswAjARe4b6N+UgpOVEjLLfE4MMbmQ==
+"@aws-sdk/util-error-constructor@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-error-constructor/-/util-error-constructor-0.1.0-preview.7.tgz#37543155014274b1c33db85ce50c17e7f297ce2c"
+  integrity sha512-sb8gruiOadl0YXG2yn0EMBkB/Oy/7y4mt8Wfl7G3crvWXcHtD7flbW7wjbFiMcQU91vi5sTaZ56hwvDA9lu0ug==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/util-hex-encoding@^0.1.0-preview.3":
@@ -425,15 +433,15 @@
   dependencies:
     tslib "^1.8.0"
 
-"@aws-sdk/util-user-agent-node@^0.1.0-preview.5":
-  version "0.1.0-preview.7"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.7.tgz#8818fe70b4e5d27907c258fbd5d75af081998274"
-  integrity sha512-28mZIA6BFB3vSmmbsfarTzixFBebthOQMcfUp7jfDVOgSCyhrB7JgYkKc6u/pupVM+ppvOaZxcSs5cDsqI5KwQ==
+"@aws-sdk/util-user-agent-node@^0.1.0-preview.9":
+  version "0.1.0-preview.9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-0.1.0-preview.9.tgz#0056f0fbccd4adf84b11ad060f61b279b822888d"
+  integrity sha512-V/1n0KAFvAIsguDXMJ9zvbJmv3j5dyOhjHKf6nhWYBR7hLYGdKA5HlZmQsoRCJf3B3whl6z1HSkmtTPOtY9Hlg==
   dependencies:
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
-"@aws-sdk/util-utf8-node@^0.1.0-preview.2":
+"@aws-sdk/util-utf8-node@^0.1.0-preview.4":
   version "0.1.0-preview.4"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-0.1.0-preview.4.tgz#8dc8e0ce43f6dc04bbcab00c87f29f9f89ebb7ad"
   integrity sha512-FxIWpC4LdKiJgJgiaLWMdZY/DbreSIRgVGO9cOlV5fI59KdN+2Aqb6sLnlp7yVbo2hiL0Hlcv7fcf4MEtELn0g==
@@ -441,24 +449,24 @@
     "@aws-sdk/util-buffer-from" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/xml-body-builder@^0.1.0-preview.4":
-  version "0.1.0-preview.5"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-body-builder/-/xml-body-builder-0.1.0-preview.5.tgz#b81e1563295dd6a7364a487e1495aae80c51322a"
-  integrity sha512-aZ8koCRV3+bgZjcFK2ixzB3y38/TMI6qsHCEYenYIY8UbLDNJNwr6xIFKlwdSgdANcTWBuScfjg2FdBa/K9SJQ==
+"@aws-sdk/xml-body-builder@^0.1.0-preview.7":
+  version "0.1.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-body-builder/-/xml-body-builder-0.1.0-preview.7.tgz#a47ffa881c91dccf8b405430dbe084be235cc142"
+  integrity sha512-4LNn5CONVhIWq3+wUWwfsSOncs9Ges8NKD9cf6pTN/VaqBcVGiFo3L0PoHLk143RTBxIsqmkY2VhVlNl5XsQSA==
   dependencies:
     "@aws-sdk/is-iterable" "^0.1.0-preview.3"
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     "@aws-sdk/xml-builder" "^0.1.0-preview.3"
     tslib "^1.8.0"
 
-"@aws-sdk/xml-body-parser@^0.1.0-preview.5":
-  version "0.1.0-preview.6"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-body-parser/-/xml-body-parser-0.1.0-preview.6.tgz#8a2ed7c5079287c34eaae4ff848c2a1a417b97e4"
-  integrity sha512-6quo9AqyUfsnE9+TwlgU5X5EZAXeAIm8D+QPhzerk4KrfDtJrV6WFpE+hkj1L3STC6n3U1M5jMhsYW8Qs3RsvA==
+"@aws-sdk/xml-body-parser@^0.1.0-preview.8":
+  version "0.1.0-preview.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-body-parser/-/xml-body-parser-0.1.0-preview.8.tgz#6529bf0fa0d7ea6ee2e71f3e23090158e3d7fa03"
+  integrity sha512-qK9+ZT5c1pj30e8td4E04ly3JczgnKAwNdJp76eTJzHXzZewQhL7VlFg2TU5UVNc/3MWSgwQHcWEtcRaOtOEiw==
   dependencies:
-    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.5"
-    "@aws-sdk/types" "^0.1.0-preview.5"
+    "@aws-sdk/protocol-timestamp" "^0.1.0-preview.7"
+    "@aws-sdk/types" "^0.1.0-preview.7"
     tslib "^1.8.0"
 
 "@aws-sdk/xml-builder@^0.1.0-preview.3":


### PR DESCRIPTION
This adds a `--concurrency=<n>` option to the scraper to make it possible to concurrently process *n* BBLs at once.  It also adds a `--no-browser` option to throw an error if a browser is ever needed to retrieve a page.

It also updates our S3 client version, and adds additional logic to ensure that S3 PUT requests are successful.
