### PR TITLE
use pdftext 4.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12.10.0
 
-ARG XPDF_VERSION=4.03
+ARG XPDF_VERSION=4.04
 
 # https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322838700
 RUN apt-get update && apt-get install -y \
@@ -44,7 +44,8 @@ RUN apt-get update && apt-get install -y \
     wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://dl.xpdfreader.com/xpdf-tools-linux-${XPDF_VERSION}.tar.gz > /xpdf.tar.gz \
+RUN apt-get update && apt-get upgrade -y \
+  && curl https://dl.xpdfreader.com/xpdf-tools-linux-${XPDF_VERSION}.tar.gz > /xpdf.tar.gz \
   && tar -zxvf /xpdf.tar.gz \
   && cp xpdf-tools-linux-${XPDF_VERSION}/bin64/pdftotext /bin \
   && rm -rf xpdf-tools-linux-${XPDF_VERSION} \

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ metrics from the statements if needed.
 
 ## Installation
 
-You will need `pdftotext` version 4.03 on your path, or defined via the
+You will need `pdftotext` version 4.04 on your path, or defined via the
 `PDFTOTEXT` environment variable (if an `.env` file is found in the root directory
 of the repository, it will be loaded). You can obtain it by downloading
 and installing one of the following:
 
-* [Xpdf command line tools (Linux)](https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz)
-* [Xpdf command line tools (Windows)](https://dl.xpdfreader.com/xpdf-tools-win-4.03.zip)
-* [Xpdf command line tools (OS X)](https://dl.xpdfreader.com/xpdf-tools-mac-4.03.tar.gz)
+* [Xpdf command line tools (Linux)](https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz)
+* [Xpdf command line tools (Windows)](https://dl.xpdfreader.com/xpdf-tools-win-4.04.zip)
+* [Xpdf command line tools (OS X)](https://dl.xpdfreader.com/xpdf-tools-mac-4.04.tar.gz)
 
 You may want to create an `.env` file to configure environment variables. This
 can be done by copying the sample file and editing it as needed:

--- a/lib/pdf-to-text.ts
+++ b/lib/pdf-to-text.ts
@@ -7,7 +7,7 @@ import tmp from 'tmp';
  * 
  * NOTE: If you ever change this, make sure to update README.md too!
  */
-export const EXPECTED_PDFTOTEXT_VERSION = '4.03';
+export const EXPECTED_PDFTOTEXT_VERSION = '4.04';
 
 const VERSION_REGEX = /pdftotext version ([\d.]+)/;
 


### PR DESCRIPTION
It seems like with each new version that make the previous one unavailable...
I was also having problems with SSL certificates in building the docker container, but adding `apt-get update && apt-get upgrade -y` solved this