### PR TITLE
make "Fee" optional in RS unit scrape regex

### DIFF
--- a/lib/extract-rentstab-units.ts
+++ b/lib/extract-rentstab-units.ts
@@ -1,5 +1,5 @@
 export function extractRentStabilizedUnits(text: string): number|null {
-  const re = /(?:Housing-Rent\s+Stabilization|Rent\s+Stabilization\s+Fee-\s+Chg)\s+(\d+)/ig;
+  const re = /(?:Housing-Rent\s+Stabilization|Rent\s+Stabilization(?:\s+Fee)?-\s+Chg)\s+(\d+)/ig;
   let total = 0;
   let match: RegExpExecArray|null = null;
 


### PR DESCRIPTION
In the files released in 2022 the line about rent stabilization fees sometimes doesn't include the word "Fee" anymore, so this makes it optional in the regex pattern