### PR TITLE
handle corrupted pdf downloads

### DIFF
--- a/doffer.ts
+++ b/doffer.ts
@@ -187,12 +187,40 @@ async function getNOPVInfo(pageGetter: PageGetter, bbl: BBL, cache: DOFCache, fi
 
   for (let link of links) {
     const name = `${link.date} NOPV for BBL ${bbl}`;
-    const text = await pageGetter.cachedDownloadAndConvertPDFToText(bbl, link.url, name, cache, `nopv-${link.date}`, ['-layout']);
+    const cacheSubkey = `soa-${link.date}`;
+    const extraFlags: PDFToTextFlags[] = ["-table"];
+    const text = await pageGetter.cachedDownloadAndConvertPDFToText(bbl, link.url, name, cache, cacheSubkey, extraFlags);
+    assertSuccessfulDownloads(text, bbl, cache, cacheSubkey, extraFlags);
     const noi = extractNetOperatingIncome(text);
     results.push({...link, noi});
   }
 
   return results;
+}
+
+// For 2021 scrape we discovered corrupted PDF files that can't be opened and
+// convert to empty text files. The scraped results look the same as a
+// successful scrape for a property with no rent stabilized units. Now we check
+// the text and if it's empty we delete our cached DF and TXT files and throw an
+// error that will get logged in the database. Then we can use the same method
+// of clearing errors to scrape again.
+
+/** If page text is empty (indicates corrupted PDF download), deletes cached PDF and TXT files and throws error */
+function assertSuccessfulDownloads(
+  pageText: string,
+  bbl: BBL,
+  cache: DOFCache,
+  cacheSubkey: string,
+  extraFlags?: PDFToTextFlags[]
+): void {
+  if (!pageText.length) {
+    const pdfToTextKey = `pdftotext-${EXPECTED_PDFTOTEXT_VERSION}` + (extraFlags || []).join("");
+    cache.delete(`pdf/${bbl.asPath()}/${cacheSubkey}.pdf`);
+    cache.delete(`txt/${bbl.asPath()}/${cacheSubkey}_${pdfToTextKey}.txt`);
+    // NOTE: Do not change this error message, we currently search for
+    // it in SQL queries in dbtool.ts!
+    throw new Error(`DOF PDF download for BBL ${bbl} was corrupted`);
+  }
 }
 
 type SOAInfo = SOALink & {
@@ -223,12 +251,17 @@ async function getSOAInfo(pageGetter: PageGetter, bbl: BBL, cache: DOFCache, fil
   const page = SidebarLinkName.propertyTaxBills;
   const html = await pageGetter.cachedGetPageHTML(bbl, page, cache, 'soa');
   const links = parseSOALinks(html).filter(filter);
+  console.log({links})
 
   for (let link of links) {
     if (link.quarter !== 1) continue;
 
     const name = `${link.date} Q1 SOA for BBL ${bbl}`;
-    const text = await pageGetter.cachedDownloadAndConvertPDFToText(bbl, link.url, name, cache, `soa-${link.date}`, ['-table']);
+    const cacheSubkey = `soa-${link.date}`;
+    const extraFlags: PDFToTextFlags[] = ["-table"];
+    const text = await pageGetter.cachedDownloadAndConvertPDFToText(bbl, link.url, name, cache, cacheSubkey, extraFlags);
+    console.log({bbl, text});
+    assertSuccessfulDownloads(text, bbl, cache, cacheSubkey, extraFlags);
     const rentStabilizedUnits = extractRentStabilizedUnits(text);
 
     results.push({...link, rentStabilizedUnits});
@@ -261,7 +294,7 @@ export async function getPropertyInfoForAddress(address: string, cache: DOFCache
   if (!geo) {
     throw new GracefulError("The search text is invalid.");
   }
-  const bbl = BBL.from(geo.pad_bbl);
+  const bbl = BBL.from(geo.addendum.pad.bbl);
 
   log(`Searching NYC DOF website for BBL ${bbl} (${geo.name}, ${geo.borough}).`);
 

--- a/doffer.ts
+++ b/doffer.ts
@@ -187,8 +187,8 @@ async function getNOPVInfo(pageGetter: PageGetter, bbl: BBL, cache: DOFCache, fi
 
   for (let link of links) {
     const name = `${link.date} NOPV for BBL ${bbl}`;
-    const cacheSubkey = `soa-${link.date}`;
-    const extraFlags: PDFToTextFlags[] = ["-table"];
+    const cacheSubkey = `nopv-${link.date}`;
+    const extraFlags: PDFToTextFlags[] = ["-layout"];
     const text = await pageGetter.cachedDownloadAndConvertPDFToText(bbl, link.url, name, cache, cacheSubkey, extraFlags);
     assertSuccessfulDownloads(text, bbl, cache, cacheSubkey, extraFlags);
     const noi = extractNetOperatingIncome(text);

--- a/doffer.ts
+++ b/doffer.ts
@@ -243,7 +243,6 @@ async function getSOAInfo(pageGetter: PageGetter, bbl: BBL, cache: DOFCache, fil
   const page = SidebarLinkName.propertyTaxBills;
   const html = await pageGetter.cachedGetPageHTML(bbl, page, cache, 'soa');
   const links = parseSOALinks(html).filter(filter);
-  console.log({links})
 
   for (let link of links) {
     if (link.quarter !== 1) continue;
@@ -252,7 +251,6 @@ async function getSOAInfo(pageGetter: PageGetter, bbl: BBL, cache: DOFCache, fil
     const cacheSubkey = `soa-${link.date}`;
     const extraFlags: PDFToTextFlags[] = ["-table"];
     const text = await pageGetter.cachedDownloadAndConvertPDFToText(bbl, link.url, name, cache, cacheSubkey, extraFlags);
-    console.log({bbl, text});
     assertSuccessfulDownloads(text, bbl, cache, cacheSubkey, extraFlags);
     const rentStabilizedUnits = extractRentStabilizedUnits(text);
 

--- a/doffer.ts
+++ b/doffer.ts
@@ -201,24 +201,16 @@ async function getNOPVInfo(pageGetter: PageGetter, bbl: BBL, cache: DOFCache, fi
 // For 2021 scrape we discovered corrupted PDF files that can't be opened and
 // convert to empty text files. The scraped results look the same as a
 // successful scrape for a property with no rent stabilized units. Now we check
-// the text and if it's empty we delete our cached DF and TXT files and throw an
+// the text and if it's empty we delete our cached PDF and TXT files and throw an
 // error that will get logged in the database. Then we can use the same method
 // of clearing errors to scrape again.
 
 /** If page text is empty (indicates corrupted PDF download), deletes cached PDF and TXT files and throws error */
-function assertSuccessfulDownloads(
-  pageText: string,
-  bbl: BBL,
-  cache: DOFCache,
-  cacheSubkey: string,
-  extraFlags?: PDFToTextFlags[]
-): void {
+function assertSuccessfulDownloads(pageText: string, bbl: BBL, cache: DOFCache, cacheSubkey: string, extraFlags?: PDFToTextFlags[]): void {
   if (!pageText.length) {
     const pdfToTextKey = `pdftotext-${EXPECTED_PDFTOTEXT_VERSION}` + (extraFlags || []).join("");
     cache.delete(`pdf/${bbl.asPath()}/${cacheSubkey}.pdf`);
     cache.delete(`txt/${bbl.asPath()}/${cacheSubkey}_${pdfToTextKey}.txt`);
-    // NOTE: Do not change this error message, we currently search for
-    // it in SQL queries in dbtool.ts!
     throw new Error(`DOF PDF download for BBL ${bbl} was corrupted`);
   }
 }

--- a/lib/geosearch.ts
+++ b/lib/geosearch.ts
@@ -6,11 +6,11 @@ import { GEO_AUTOCOMPLETE_URL } from "../static/geo-autocomplete";
  * if/where they are formally specified.
  */
 export enum GeoSearchBoroughGid {
-  Manhattan = 'whosonfirst:borough:1',
-  Bronx = 'whosonfirst:borough:2',
-  Brooklyn = 'whosonfirst:borough:3',
-  Queens = 'whosonfirst:borough:4',
-  StatenIsland = 'whosonfirst:borough:5',
+  Manhattan = 'whosonfirst:borough:421205771',
+  Bronx = 'whosonfirst:borough:421205773',
+  Brooklyn = 'whosonfirst:borough:421205765',
+  Queens = 'whosonfirst:borough:421205767',
+  StatenIsland = 'whosonfirst:borough:421205775',
 }
 
 /**
@@ -52,8 +52,15 @@ export interface GeoSearchProperties {
   /** e.g. "150 COURT STREET, Brooklyn, New York, NY, USA" */
   label: string;
 
-  /** e.g., "3012380016" */
-  pad_bbl: string;
+  /**
+   * The 10-digit padded Borough-Block-Lot (BBL) number for the
+   * property, e.g. "3002920026".
+   */
+  addendum: {
+    pad: {
+      bbl: string;
+    };
+  };
 }
 
 /**

--- a/static/geo-autocomplete.ts
+++ b/static/geo-autocomplete.ts
@@ -5,7 +5,7 @@ import { GeoSearchResults } from "../lib/geosearch";
  *
  * https://geosearch.planninglabs.nyc/docs/#autocomplete
  */
-export const GEO_AUTOCOMPLETE_URL = 'https://geosearch.planninglabs.nyc/v1/autocomplete';
+export const GEO_AUTOCOMPLETE_URL = 'https://geosearch.planninglabs.nyc/v2/autocomplete';
 
 /**
  * Options for the requester constructor.


### PR DESCRIPTION
This year in scraping the 2021 Statement of Account (SOA) files for counts of rent stabilized units we encountered a new problem that Sam and The City team discovered. There are an unknown number of properties where the PDF files are corrupted ([example](https://nyc-doffer.s3.amazonaws.com/corrupted-soa-example.pdf.br)). They can't be opened and when converted to txt files it's completely blank. There is some data in there, so you can't detect it as the PDF, only once converted to text. The way our scraper was set up, when we parse the txt file for the rent stabilized units these files would return nothing just like a real file that simply doesn't have units.

So we need to look back through all of the cached files and see if the txt files are empty. If they are, we need to delete the cached files and redo the process starting with freshly downloaded pdf files. 

I've added a step to the existing scraping process, right before parsing out the unit counts, to check if the txt file is completely empty. If it is, we delete the PDF and TXT files from the cache, and log an error in the database. Because of the unpredictable nature of the DOF scraping, we already have a process for keeping track of any errors and easily retrying the scrape. Also, because every file along the way is cached, we should be able to re-scrape all of the BBLs and it will only be downloading the cached TXT file initially, and will logging the errors and deleting the bad files from the cache. Then we'll know how many of these cases there are. Then we can rerun the scrape on just those ones, starting at the point of getting the PDF (skipping the slowest part of part of navigating the DOF site), and getting the correct unit counts.

This PR also updates geosearch for the new v2 api, since that's used in the webapp for easy local testing and v1 is offline now.