### PR TITLE
fix dockerfile hanging on tzdata step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM node:12.10.0
 
 ARG XPDF_VERSION=4.04
 
+# https://stackoverflow.com/a/76095392/7051239
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
+# https://grigorkh.medium.com/fix-tzdata-hangs-docker-image-build-cdb52cc3360d
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # https://github.com/Googlechrome/puppeteer/issues/290#issuecomment-322838700
 RUN apt-get update && apt-get install -y \
     gconf-service \


### PR DESCRIPTION
When building the docker container there were a couple new issues breaking things:

1. There are some debian security files that couldn't be found, and this was solved by this [SO answer](https://stackoverflow.com/a/76095392/7051239) updating source lists so it looks in the correct place where these files now live
2. Then it was getting hung up on `tzdata` when installing packages. This [medium article](https://grigorkh.medium.com/fix-tzdata-hangs-docker-image-build-cdb52cc3360d) explains that there is some issue with it needing a timezone and it just waits for you to interactively enter it, but we can just specify it upfront. 