### PR TITLE
remove apt-get upgrade from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y \
     wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update \
   && curl https://dl.xpdfreader.com/xpdf-tools-linux-${XPDF_VERSION}.tar.gz > /xpdf.tar.gz \
   && tar -zxvf /xpdf.tar.gz \
   && cp xpdf-tools-linux-${XPDF_VERSION}/bin64/pdftotext /bin \


### PR DESCRIPTION
For some reason the docker container fails to build on `apt-get upgrade` only on the EC2 instance. It ttrys to install and set up python3.5 and says it's not configured. I started looking into how to do this, but I don't think we actually need to run this upgrade, so just removed it and everything built and runs fine. 